### PR TITLE
doc: update url with deprecated lib

### DIFF
--- a/docs/client-server-communication/allow-evolutivity.mdx
+++ b/docs/client-server-communication/allow-evolutivity.mdx
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 Notre parti pris est de faire du TypeScript de bout en bout, mais sachez qu'en utilisant tRPC vous ne vous bridez pas à simplement générer des clients TypeScript. Vous pouvez très bien faire de votre produit un "produit API" de qualité avec des clients API dans différents langages.
 
-Comme vos endpoints sont typés avec tRPC, vous pouvez utiliser [trpc-openapi](https://github.com/jlalmes/trpc-openapi) afin d'exposer votre API sous le standard [OpenAPI](https://www.openapis.org/) afin d'avoir une API REST. Ce standard vous permet même ensuite de [générer des clients dans n'importe quel langage](https://github.com/OpenAPITools/openapi-generator).
+Comme vos endpoints sont typés avec tRPC, vous pouvez utiliser [trpc-to-openapi](https://www.npmjs.com/package/trpc-to-openapi) afin d'exposer votre API sous le standard [OpenAPI](https://www.openapis.org/) afin d'avoir une API REST. Ce standard vous permet même ensuite de [générer des clients dans n'importe quel langage](https://github.com/OpenAPITools/openapi-generator).


### PR DESCRIPTION
Le repo GitHub https://github.com/trpc/trpc-openapi a été archivé par son auteur. 
Mise à jour de la doc qui le citait, avec le lien proposé.

<img width="992" height="532" alt="image" src="https://github.com/user-attachments/assets/52d63adc-2306-40a8-9579-bb303fb61d3f" />
