### PR TITLE
doc: correction typo + reformulation

### DIFF
--- a/docs/client-server-communication/prefer-api-to-frontend-caching.mdx
+++ b/docs/client-server-communication/prefer-api-to-frontend-caching.mdx
@@ -14,5 +14,5 @@ Sauf qu'en faisant cela vous vous lancez d'office dans plusieurs complications :
 Comme expliqué pour la [mise en cache backend des données](database-for-everything/cache.mdx), il ne sert à rien d'essayer d'optimiser avant de rencontrer certaines limites. Et ce qui est sûr, c'est qu'un simple backend avec une base de données simple devrait largement supporter vos quelques premiers milliers d'utilisateurs sans essayer d'optimiser le frontend.
 
 :::note
-Vous verrez dans le chapitre sur [le framework backend](backend-framework/index.mdx) que nous n'utilisons même pas besoin de librairie tierce pour gérer l'état de nos composants frontends.
+Comme décrit dans le chapitre sur [le framework backend](backend-framework/index.mdx), nous n'utilisons même pas de librairie tierce pour gérer l'état de nos composants frontends.
 :::


### PR DESCRIPTION
J'ai reformulé car il était dit que la page sur le framework backend allait être évoqué plus tard, or elle est évoquée avant dans la navigation.  Utilisation d'une formulation plus neutre.